### PR TITLE
Adding stricter types for properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "description": "Typescript package boilerplate template",
   "main": "dist/index.js",
-  "types": "dist/index.d.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "./node_modules/typescript/bin/tsc -p ./tsconfig.build.json",
     "lint": "eslint . --ext .js,.ts",

--- a/src/ITiledMapProperty.ts
+++ b/src/ITiledMapProperty.ts
@@ -1,10 +1,53 @@
 import { z } from 'zod';
 
-export const isTiledMapProperty = z.object({
+const literalSchema = z.union([z.string(), z.number(), z.boolean(), z.null()]);
+type Literal = z.infer<typeof literalSchema>;
+type Json = Literal | { [key: string]: Json } | Json[];
+const jsonSchema: z.ZodType<Json> = z.lazy(() =>
+  z.union([literalSchema, z.array(jsonSchema), z.record(jsonSchema)]),
+);
+
+const isTiledMapStringProperty = z.object({
   name: z.string(),
-  type: z.string(),
-  value: z.unknown().optional(),
+  type: z.union([z.literal('string'), z.literal('color'), z.literal('file')]),
+  value: z.string().optional(),
   propertytype: z.string().optional(),
 });
+
+const isTiledMapIntProperty = z.object({
+  name: z.string(),
+  type: z.union([z.literal('int'), z.literal('object')]),
+  value: z.number().int().optional(),
+  propertytype: z.string().optional(),
+});
+
+const isTiledMapFloatProperty = z.object({
+  name: z.string(),
+  type: z.literal('float'),
+  value: z.number().optional(),
+  propertytype: z.string().optional(),
+});
+
+const isTiledMapBoolProperty = z.object({
+  name: z.string(),
+  type: z.literal('bool'),
+  value: z.boolean().optional(),
+  propertytype: z.string().optional(),
+});
+
+const isTiledMapClassProperty = z.object({
+  name: z.string(),
+  type: z.literal('class'),
+  value: jsonSchema.optional(),
+  propertytype: z.string().optional(),
+});
+
+export const isTiledMapProperty = z.union([
+  isTiledMapStringProperty,
+  isTiledMapIntProperty,
+  isTiledMapFloatProperty,
+  isTiledMapBoolProperty,
+  isTiledMapClassProperty,
+]);
 
 export type ITiledMapProperty = z.infer<typeof isTiledMapProperty>;


### PR DESCRIPTION
Using a discriminated union based on the "type" property to assert the type of the "value" property.