### PR TITLE
Renaming ALL type guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,29 +6,36 @@ When working with [Tiled](https://www.mapeditor.org/) maps, it can be useful to 
 
 This package contains a set of interfaces that map the [Tiled map JSON format](https://doc.mapeditor.org/en/stable/reference/json-map-format/).
 
-Moreover, this package comes with [type guards](https://www.typescriptlang.org/docs/handbook/advanced-types.html) that will allow
+Moreover, this package comes with [Zod type guards](https://github.com/colinhacks/zod) that will allow
 you to actually **check** that the JSON file ou are reading is actually a well-formed Tiled map.
 
 Available interfaces:
 
-- `ITiledMap` (typeguard `isTiledMap`)
-- `ITiledMapLayer` (typeguard `isTiledMapLayer`)
-  - `ITiledMapGroupLayer` (typeguard `isTiledMapGroupLayer`)
-  - `ITiledMapImageLayer` (typeguard `isTiledMapImageLayer`)
-  - `ITiledMapObjectLayer` (typeguard `isTiledMapObjectLayer`)
-    - `ITiledMapObject` (typeguard `isTiledMapObject`)
-      - `ITiledMapText` (typeguard `isTiledMapText`)
-      - `ITiledMapPoint` (typeguard `isTiledMapPoint`)
-  - `ITiledMapTileLayer` (typeguard `isTiledMapTileLayer`)
-- `ITiledMapTileset` (typeguard `isTiledMapTileset`)
-  - `ITiledMapTile` (typeguard `isTiledMapTile`)
-    - `ITiledMapWangColor` (typeguard `isTiledMapWangColor`)
-    - `ITiledMapWangSet` (typeguard `isTiledMapWangSet`)
-    - `ITiledMapWangTile` (typeguard `isTiledMapWangTile`)
-- `ITiledMapChunk` (typeguard `isTiledMapChunk`)
-- `ITiledMapFrame` (typeguard `isTiledMapFrame`)
-- `ITiledMapGrid` (typeguard `isTiledMapGrid`)
-- `ITiledMapOffset` (typeguard `isTiledMapOffset`)
-- `ITiledMapProperty` (typeguard `isTiledMapProperty`)
-- `ITiledMapTerrain` (typeguard `isTiledMapTerrain`)
-- `ITiledMapTransformations` (typeguard `isTiledMapTransformations`)
+- `ITiledMap`
+- `ITiledMapLayer`
+  - `ITiledMapGroupLayer`
+  - `ITiledMapImageLayer`
+  - `ITiledMapObjectLayer`
+    - `ITiledMapObject`
+      - `ITiledMapText`
+      - `ITiledMapPoint`
+  - `ITiledMapTileLayer`
+- `ITiledMapTileset`
+  - `ITiledMapTile`
+    - `ITiledMapWangColor`
+    - `ITiledMapWangSet`
+    - `ITiledMapWangTile`
+- `ITiledMapChunk`
+- `ITiledMapFrame`
+- `ITiledMapGrid`
+- `ITiledMapOffset`
+- `ITiledMapProperty`
+- `ITiledMapTerrain`
+- `ITiledMapTransformations`
+
+Usage:
+
+```ts
+// This will throw an error if "data" is not matching the type ITiledMap
+const map: ITiledMap = ITiledMap.parse(data);
+```

--- a/src/ITiledMap.ts
+++ b/src/ITiledMap.ts
@@ -1,12 +1,12 @@
-import { isTiledMapProperty } from './ITiledMapProperty';
-import { isTiledMapLayer } from './ITiledMapLayer';
-import { isTiledMapTileset } from './ITiledMapTileset';
+import { ITiledMapProperty } from './ITiledMapProperty';
+import { ITiledMapLayer } from './ITiledMapLayer';
+import { ITiledMapTileset } from './ITiledMapTileset';
 import { z } from 'zod';
 
-export const isTiledMap = z.object({
-  layers: isTiledMapLayer.array(),
+export const ITiledMap = z.object({
+  layers: ITiledMapLayer.array(),
   tiledversion: z.string(),
-  tilesets: isTiledMapTileset.array(),
+  tilesets: ITiledMapTileset.array(),
   type: z.literal('map'),
   backgroundcolor: z.string().optional(),
   compressionlevel: z.number().optional(),
@@ -18,7 +18,7 @@ export const isTiledMap = z.object({
   orientation: z.enum(['orthogonal', 'isometric', 'staggered', 'hexagonal']).optional(),
   parallaxoriginx: z.number().optional(),
   parallaxoriginy: z.number().optional(),
-  properties: isTiledMapProperty.array().optional(),
+  properties: ITiledMapProperty.array().optional(),
   renderorder: z.enum(['right-down', 'right-up', 'left-down', 'left-up']).optional(),
   staggeraxis: z.enum(['x', 'y']).optional(),
   staggerindex: z.enum(['odd', 'even']).optional(),
@@ -29,4 +29,4 @@ export const isTiledMap = z.object({
   width: z.number().optional(),
 });
 
-export type ITiledMap = z.infer<typeof isTiledMap>;
+export type ITiledMap = z.infer<typeof ITiledMap>;

--- a/src/ITiledMapChunk.ts
+++ b/src/ITiledMapChunk.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const isTiledMapChunk = z.object({
+export const ITiledMapChunk = z.object({
   data: z.union([z.string(), z.number().array()]),
   height: z.number(),
   width: z.number(),
@@ -8,4 +8,4 @@ export const isTiledMapChunk = z.object({
   y: z.number(),
 });
 
-export type ITiledMapChunk = z.infer<typeof isTiledMapChunk>;
+export type ITiledMapChunk = z.infer<typeof ITiledMapChunk>;

--- a/src/ITiledMapFrame.ts
+++ b/src/ITiledMapFrame.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 
-export const isTiledMapFrame = z.object({
+export const ITiledMapFrame = z.object({
   duration: z.number(),
   tileid: z.number(),
 });
 
-export type ITiledMapFrame = z.infer<typeof isTiledMapFrame>;
+export type ITiledMapFrame = z.infer<typeof ITiledMapFrame>;

--- a/src/ITiledMapGrid.ts
+++ b/src/ITiledMapGrid.ts
@@ -1,9 +1,9 @@
 import { z } from 'zod';
 
-export const isTiledMapGrid = z.object({
+export const ITiledMapGrid = z.object({
   width: z.number(),
   height: z.number(),
   orientation: z.enum(['orthogonal', 'isometric']),
 });
 
-export type ITiledMapGrid = z.infer<typeof isTiledMapGrid>;
+export type ITiledMapGrid = z.infer<typeof ITiledMapGrid>;

--- a/src/ITiledMapGroupLayer.ts
+++ b/src/ITiledMapGroupLayer.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { isTiledMapProperty, ITiledMapProperty } from './ITiledMapProperty';
-import { isTiledMapLayer, ITiledMapLayer } from './ITiledMapLayer';
+import { ITiledMapProperty } from './ITiledMapProperty';
+import { ITiledMapLayer } from './ITiledMapLayer';
 
 interface TiledMapGroupLayerOptional {
   height: number;
@@ -28,12 +28,12 @@ export interface TiledMapGroupLayer extends Partial<TiledMapGroupLayerOptional> 
   layers: ITiledMapLayer[];
 }
 
-export const isTiledMapGroupLayer: z.ZodType<TiledMapGroupLayer> = z.lazy(() =>
+export const ITiledMapGroupLayer: z.ZodType<TiledMapGroupLayer> = z.lazy(() =>
   z.object({
     name: z.string(),
     opacity: z.number(),
     type: z.literal('group'),
-    layers: isTiledMapLayer.array(),
+    layers: ITiledMapLayer.array(),
     visible: z.boolean(),
 
     height: z.number().optional(),
@@ -44,7 +44,7 @@ export const isTiledMapGroupLayer: z.ZodType<TiledMapGroupLayer> = z.lazy(() =>
     offsety: z.number().optional(),
     parallaxx: z.number().optional(),
     parallaxy: z.number().optional(),
-    properties: isTiledMapProperty.array().optional(),
+    properties: ITiledMapProperty.array().optional(),
     startx: z.number().optional(),
     starty: z.number().optional(),
     tintcolor: z.string().optional(),
@@ -54,4 +54,4 @@ export const isTiledMapGroupLayer: z.ZodType<TiledMapGroupLayer> = z.lazy(() =>
   }),
 );
 
-export type ITiledMapGroupLayer = z.infer<typeof isTiledMapGroupLayer>;
+export type ITiledMapGroupLayer = z.infer<typeof ITiledMapGroupLayer>;

--- a/src/ITiledMapImageLayer.ts
+++ b/src/ITiledMapImageLayer.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
-import { isTiledMapProperty } from './ITiledMapProperty';
+import { ITiledMapProperty } from './ITiledMapProperty';
 
-export const isTiledMapImageLayer = z.object({
+export const ITiledMapImageLayer = z.object({
   image: z.string(),
   name: z.string(),
   opacity: z.number(),
@@ -14,7 +14,7 @@ export const isTiledMapImageLayer = z.object({
   offsety: z.number().optional(),
   parallaxx: z.number().optional(),
   parallaxy: z.number().optional(),
-  properties: isTiledMapProperty.array().optional(),
+  properties: ITiledMapProperty.array().optional(),
   repeatx: z.boolean().optional(),
   repeaty: z.boolean().optional(),
   startx: z.number().optional(),
@@ -26,4 +26,4 @@ export const isTiledMapImageLayer = z.object({
   y: z.number().optional(),
 });
 
-export type ITiledMapImageLayer = z.infer<typeof isTiledMapImageLayer>;
+export type ITiledMapImageLayer = z.infer<typeof ITiledMapImageLayer>;

--- a/src/ITiledMapLayer.ts
+++ b/src/ITiledMapLayer.ts
@@ -1,14 +1,14 @@
 import { z } from 'zod';
-import { isTiledMapTileLayer } from './ITiledMapTileLayer';
-import { isTiledMapGroupLayer } from './ITiledMapGroupLayer';
-import { isTiledMapObjectLayer } from './ITiledMapObjectLayer';
-import { isTiledMapImageLayer } from './ITiledMapImageLayer';
+import { ITiledMapTileLayer } from './ITiledMapTileLayer';
+import { ITiledMapGroupLayer } from './ITiledMapGroupLayer';
+import { ITiledMapObjectLayer } from './ITiledMapObjectLayer';
+import { ITiledMapImageLayer } from './ITiledMapImageLayer';
 
-export const isTiledMapLayer = z.union([
-  isTiledMapTileLayer,
-  isTiledMapGroupLayer,
-  isTiledMapObjectLayer,
-  isTiledMapImageLayer,
+export const ITiledMapLayer = z.union([
+  ITiledMapTileLayer,
+  ITiledMapGroupLayer,
+  ITiledMapObjectLayer,
+  ITiledMapImageLayer,
 ]);
 
-export type ITiledMapLayer = z.infer<typeof isTiledMapLayer>;
+export type ITiledMapLayer = z.infer<typeof ITiledMapLayer>;

--- a/src/ITiledMapObject.ts
+++ b/src/ITiledMapObject.ts
@@ -1,9 +1,9 @@
 import { z } from 'zod';
-import { isTiledMapProperty } from './ITiledMapProperty';
-import { isTiledMapPoint } from './ITiledMapPoint';
-import { isTiledMapText } from './ITiledMapText';
+import { ITiledMapProperty } from './ITiledMapProperty';
+import { ITiledMapPoint } from './ITiledMapPoint';
+import { ITiledMapText } from './ITiledMapText';
 
-export const isTiledMapObject = z.object({
+export const ITiledMapObject = z.object({
   id: z.number(),
   name: z.string(),
   visible: z.boolean(),
@@ -14,15 +14,15 @@ export const isTiledMapObject = z.object({
   gid: z.boolean().optional(),
   height: z.number().optional(),
   point: z.boolean().optional(),
-  polygon: isTiledMapPoint.array().optional(),
-  polyline: isTiledMapPoint.array().optional(),
-  properties: isTiledMapProperty.array().optional(),
+  polygon: ITiledMapPoint.array().optional(),
+  polyline: ITiledMapPoint.array().optional(),
+  properties: ITiledMapProperty.array().optional(),
   rotation: z.number().optional(),
   template: z.string().optional(),
-  text: isTiledMapText.optional(),
+  text: ITiledMapText.optional(),
   type: z.string().optional(),
   class: z.string().optional(),
   width: z.number().optional(),
 });
 
-export type ITiledMapObject = z.infer<typeof isTiledMapObject>;
+export type ITiledMapObject = z.infer<typeof ITiledMapObject>;

--- a/src/ITiledMapObjectLayer.ts
+++ b/src/ITiledMapObjectLayer.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod';
-import { isTiledMapProperty } from './ITiledMapProperty';
-import { isTiledMapObject } from './ITiledMapObject';
+import { ITiledMapProperty } from './ITiledMapProperty';
+import { ITiledMapObject } from './ITiledMapObject';
 
-export const isTiledMapObjectLayer = z.object({
+export const ITiledMapObjectLayer = z.object({
   name: z.string(),
-  objects: isTiledMapObject.array(),
+  objects: ITiledMapObject.array(),
   opacity: z.number(),
   type: z.literal('objectgroup'),
   visible: z.boolean(),
@@ -16,7 +16,7 @@ export const isTiledMapObjectLayer = z.object({
   offsety: z.number().optional(),
   parallaxx: z.number().optional(),
   parallaxy: z.number().optional(),
-  properties: isTiledMapProperty.array().optional(),
+  properties: ITiledMapProperty.array().optional(),
   startx: z.number().optional(),
   starty: z.number().optional(),
   tintcolor: z.string().optional(),
@@ -26,4 +26,4 @@ export const isTiledMapObjectLayer = z.object({
   y: z.number().optional(),
 });
 
-export type ITiledMapObjectLayer = z.infer<typeof isTiledMapObjectLayer>;
+export type ITiledMapObjectLayer = z.infer<typeof ITiledMapObjectLayer>;

--- a/src/ITiledMapOffset.ts
+++ b/src/ITiledMapOffset.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 
-export const isTiledMapOffset = z.object({
+export const ITiledMapOffset = z.object({
   x: z.number(),
   y: z.number(),
 });
 
-export type ITiledMapOffset = z.infer<typeof isTiledMapOffset>;
+export type ITiledMapOffset = z.infer<typeof ITiledMapOffset>;

--- a/src/ITiledMapPoint.ts
+++ b/src/ITiledMapPoint.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 
-export const isTiledMapPoint = z.object({
+export const ITiledMapPoint = z.object({
   x: z.number(),
   y: z.number(),
 });
 
-export type ITiledMapPoint = z.infer<typeof isTiledMapPoint>;
+export type ITiledMapPoint = z.infer<typeof ITiledMapPoint>;

--- a/src/ITiledMapProperty.ts
+++ b/src/ITiledMapProperty.ts
@@ -7,47 +7,47 @@ const jsonSchema: z.ZodType<Json> = z.lazy(() =>
   z.union([literalSchema, z.array(jsonSchema), z.record(jsonSchema)]),
 );
 
-const isTiledMapStringProperty = z.object({
+const ITiledMapStringProperty = z.object({
   name: z.string(),
   type: z.union([z.literal('string'), z.literal('color'), z.literal('file')]),
   value: z.string().optional(),
   propertytype: z.string().optional(),
 });
 
-const isTiledMapIntProperty = z.object({
+const ITiledMapIntProperty = z.object({
   name: z.string(),
   type: z.union([z.literal('int'), z.literal('object')]),
   value: z.number().int().optional(),
   propertytype: z.string().optional(),
 });
 
-const isTiledMapFloatProperty = z.object({
+const ITiledMapFloatProperty = z.object({
   name: z.string(),
   type: z.literal('float'),
   value: z.number().optional(),
   propertytype: z.string().optional(),
 });
 
-const isTiledMapBoolProperty = z.object({
+const ITiledMapBoolProperty = z.object({
   name: z.string(),
   type: z.literal('bool'),
   value: z.boolean().optional(),
   propertytype: z.string().optional(),
 });
 
-const isTiledMapClassProperty = z.object({
+const ITiledMapClassProperty = z.object({
   name: z.string(),
   type: z.literal('class'),
   value: jsonSchema.optional(),
   propertytype: z.string().optional(),
 });
 
-export const isTiledMapProperty = z.union([
-  isTiledMapStringProperty,
-  isTiledMapIntProperty,
-  isTiledMapFloatProperty,
-  isTiledMapBoolProperty,
-  isTiledMapClassProperty,
+export const ITiledMapProperty = z.union([
+  ITiledMapStringProperty,
+  ITiledMapIntProperty,
+  ITiledMapFloatProperty,
+  ITiledMapBoolProperty,
+  ITiledMapClassProperty,
 ]);
 
-export type ITiledMapProperty = z.infer<typeof isTiledMapProperty>;
+export type ITiledMapProperty = z.infer<typeof ITiledMapProperty>;

--- a/src/ITiledMapTerrain.ts
+++ b/src/ITiledMapTerrain.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod';
-import { isTiledMapProperty } from './ITiledMapProperty';
+import { ITiledMapProperty } from './ITiledMapProperty';
 
-export const isTiledMapTerrain = z.object({
+export const ITiledMapTerrain = z.object({
   name: z.string(),
   tile: z.number(),
-  properties: isTiledMapProperty.array().optional(),
+  properties: ITiledMapProperty.array().optional(),
 });
 
-export type ITiledMapTerrain = z.infer<typeof isTiledMapTerrain>;
+export type ITiledMapTerrain = z.infer<typeof ITiledMapTerrain>;

--- a/src/ITiledMapText.ts
+++ b/src/ITiledMapText.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const isTiledMapText = z.object({
+export const ITiledMapText = z.object({
   text: z.string(),
 
   bold: z.boolean().optional(),
@@ -16,4 +16,4 @@ export const isTiledMapText = z.object({
   wrap: z.boolean().optional(),
 });
 
-export type ITiledMapText = z.infer<typeof isTiledMapText>;
+export type ITiledMapText = z.infer<typeof ITiledMapText>;

--- a/src/ITiledMapTile.ts
+++ b/src/ITiledMapTile.ts
@@ -1,13 +1,13 @@
 import { z } from 'zod';
-import { isTiledMapFrame } from './ITiledMapFrame';
-import { isTiledMapObjectLayer } from './ITiledMapObjectLayer';
-import { isTiledMapProperty } from './ITiledMapProperty';
-import { isTiledMapTerrain } from './ITiledMapTerrain';
+import { ITiledMapFrame } from './ITiledMapFrame';
+import { ITiledMapObjectLayer } from './ITiledMapObjectLayer';
+import { ITiledMapProperty } from './ITiledMapProperty';
+import { ITiledMapTerrain } from './ITiledMapTerrain';
 
-export const isTiledMapTile = z.object({
+export const ITiledMapTile = z.object({
   id: z.number(),
 
-  animation: isTiledMapFrame.array().optional(),
+  animation: ITiledMapFrame.array().optional(),
   image: z.string().optional(),
   imageheight: z.number().optional(),
   imagewidth: z.number().optional(),
@@ -15,12 +15,12 @@ export const isTiledMapTile = z.object({
   y: z.number().optional(),
   width: z.number().optional(),
   height: z.number().optional(),
-  objectgroup: isTiledMapObjectLayer.array().optional(),
+  objectgroup: ITiledMapObjectLayer.array().optional(),
   probability: z.number().optional(),
-  properties: isTiledMapProperty.array().optional(),
+  properties: ITiledMapProperty.array().optional(),
   class: z.string().optional(),
-  terrain: isTiledMapTerrain.array().optional(),
+  terrain: ITiledMapTerrain.array().optional(),
   type: z.string().optional(),
 });
 
-export type ITiledMapTile = z.infer<typeof isTiledMapTile>;
+export type ITiledMapTile = z.infer<typeof ITiledMapTile>;

--- a/src/ITiledMapTileLayer.ts
+++ b/src/ITiledMapTileLayer.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
-import { isTiledMapProperty } from './ITiledMapProperty';
-import { isTiledMapChunk } from './ITiledMapChunk';
+import { ITiledMapProperty } from './ITiledMapProperty';
+import { ITiledMapChunk } from './ITiledMapChunk';
 
-export const isTiledMapTileLayer = z.object({
+export const ITiledMapTileLayer = z.object({
   data: z.union([z.string(), z.number().array()]),
   height: z.number(),
   id: z.number(),
@@ -12,14 +12,14 @@ export const isTiledMapTileLayer = z.object({
   visible: z.boolean(),
   width: z.number(),
 
-  chunks: isTiledMapChunk.array().optional(),
+  chunks: ITiledMapChunk.array().optional(),
   compression: z.string().optional(),
   encoding: z.enum(['csv', 'base64']).optional(),
   offsetx: z.number().optional(),
   offsety: z.number().optional(),
   parallaxx: z.number().optional(),
   parallaxy: z.number().optional(),
-  properties: isTiledMapProperty.array().optional(),
+  properties: ITiledMapProperty.array().optional(),
   startx: z.number().optional(),
   starty: z.number().optional(),
   tintcolor: z.string().optional(),
@@ -28,4 +28,4 @@ export const isTiledMapTileLayer = z.object({
   y: z.number().optional(),
 });
 
-export type ITiledMapTileLayer = z.infer<typeof isTiledMapTileLayer>;
+export type ITiledMapTileLayer = z.infer<typeof ITiledMapTileLayer>;

--- a/src/ITiledMapTileset.ts
+++ b/src/ITiledMapTileset.ts
@@ -1,13 +1,13 @@
 import { z } from 'zod';
-import { isTiledMapProperty } from './ITiledMapProperty';
-import { isTiledMapTerrain } from './ITiledMapTerrain';
-import { isTiledMapGrid } from './ITiledMapGrid';
-import { isTiledMapOffset } from './ITiledMapOffset';
-import { isTiledMapTile } from './ITiledMapTile';
-import { isTiledMapTransformations } from './ITiledMapTransformations';
-import { isTiledMapWangSet } from './ITiledMapWangSet';
+import { ITiledMapProperty } from './ITiledMapProperty';
+import { ITiledMapTerrain } from './ITiledMapTerrain';
+import { ITiledMapGrid } from './ITiledMapGrid';
+import { ITiledMapOffset } from './ITiledMapOffset';
+import { ITiledMapTile } from './ITiledMapTile';
+import { ITiledMapTransformations } from './ITiledMapTransformations';
+import { ITiledMapWangSet } from './ITiledMapWangSet';
 
-export const isTiledMapTileset = z.object({
+export const ITiledMapTileset = z.object({
   name: z.string(),
   image: z.string(),
 
@@ -15,29 +15,29 @@ export const isTiledMapTileset = z.object({
   columns: z.number().optional(),
   fillmode: z.enum(['stretch', 'preserve-aspect-fit']).optional(),
   firstgid: z.number().optional(),
-  grid: isTiledMapGrid.optional(),
+  grid: ITiledMapGrid.optional(),
   id: z.number().optional(),
   imageheight: z.number().optional(),
   imagewidth: z.number().optional(),
   margin: z.number().optional(),
   objectalignment: z.string().optional(),
-  properties: isTiledMapProperty.array().optional(),
+  properties: ITiledMapProperty.array().optional(),
   source: z.string().optional(),
   spacing: z.number().optional(),
-  terrains: isTiledMapTerrain.array().optional(),
+  terrains: ITiledMapTerrain.array().optional(),
   tilecount: z.number().optional(),
   tiledversion: z.string().optional(),
   tileheight: z.number().optional(),
-  tileoffset: isTiledMapOffset.optional(),
+  tileoffset: ITiledMapOffset.optional(),
   tilerendersize: z.enum(['tile', 'grid']).optional(),
-  tiles: isTiledMapTile.array().optional(),
+  tiles: ITiledMapTile.array().optional(),
   tilewidth: z.number().optional(),
-  transformations: isTiledMapTransformations.optional(),
+  transformations: ITiledMapTransformations.optional(),
   transparentcolor: z.string().optional(),
   type: z.literal('tileset').optional(),
   class: z.string().optional(),
   version: z.union([z.string(), z.number()]).optional(),
-  wangsets: isTiledMapWangSet.array().optional(),
+  wangsets: ITiledMapWangSet.array().optional(),
 });
 
-export type ITiledMapTileset = z.infer<typeof isTiledMapTileset>;
+export type ITiledMapTileset = z.infer<typeof ITiledMapTileset>;

--- a/src/ITiledMapTransformations.ts
+++ b/src/ITiledMapTransformations.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod';
 
-export const isTiledMapTransformations = z.object({
+export const ITiledMapTransformations = z.object({
   hflip: z.boolean().optional(),
   vflip: z.boolean().optional(),
   rotate: z.boolean().optional(),
   preferuntransformed: z.boolean().optional(),
 });
 
-export type ITiledMapTransformations = z.infer<typeof isTiledMapTransformations>;
+export type ITiledMapTransformations = z.infer<typeof ITiledMapTransformations>;

--- a/src/ITiledMapWangColor.ts
+++ b/src/ITiledMapWangColor.ts
@@ -1,15 +1,15 @@
 import { z } from 'zod';
-import { isTiledMapProperty } from './ITiledMapProperty';
+import { ITiledMapProperty } from './ITiledMapProperty';
 
-export const isTiledMapWangColor = z.object({
+export const ITiledMapWangColor = z.object({
   name: z.string(),
   color: z.string(),
   tile: z.number(),
 
   probability: z.number(),
-  properties: isTiledMapProperty.array(),
+  properties: ITiledMapProperty.array(),
   type: z.string().optional(),
   class: z.string().optional(),
 });
 
-export type ITiledMapWangColor = z.infer<typeof isTiledMapWangColor>;
+export type ITiledMapWangColor = z.infer<typeof ITiledMapWangColor>;

--- a/src/ITiledMapWangSet.ts
+++ b/src/ITiledMapWangSet.ts
@@ -1,17 +1,17 @@
 import { z } from 'zod';
-import { isTiledMapProperty } from './ITiledMapProperty';
-import { isTiledMapWangColor } from './ITiledMapWangColor';
-import { isTiledMapWangTile } from './ITiledMapWangTile';
+import { ITiledMapProperty } from './ITiledMapProperty';
+import { ITiledMapWangColor } from './ITiledMapWangColor';
+import { ITiledMapWangTile } from './ITiledMapWangTile';
 
-export const isTiledMapWangSet = z.object({
+export const ITiledMapWangSet = z.object({
   name: z.string(),
   tile: z.number(),
 
-  colors: isTiledMapWangColor.array().optional(),
-  properties: isTiledMapProperty.array().optional(),
-  wangtiles: isTiledMapWangTile.array().optional(),
+  colors: ITiledMapWangColor.array().optional(),
+  properties: ITiledMapProperty.array().optional(),
+  wangtiles: ITiledMapWangTile.array().optional(),
   type: z.enum(['corner', 'edge', 'mixed']),
   class: z.string().optional(),
 });
 
-export type ITiledMapWangSet = z.infer<typeof isTiledMapWangSet>;
+export type ITiledMapWangSet = z.infer<typeof ITiledMapWangSet>;

--- a/src/ITiledMapWangTile.ts
+++ b/src/ITiledMapWangTile.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 
-export const isTiledMapWangTile = z.object({
+export const ITiledMapWangTile = z.object({
   tileid: z.string(),
   wangid: z.number().array(),
 });
 
-export type ITiledMapWangTile = z.infer<typeof isTiledMapWangTile>;
+export type ITiledMapWangTile = z.infer<typeof ITiledMapWangTile>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,6 @@ export * from './ITiledMapWangColor';
 export * from './ITiledMapWangSet';
 export * from './ITiledMapWangTile';
 export * from './ITiledMapTileLayer';
-export { isTiledMapGroupLayer } from './ITiledMapGroupLayer';
-export type { ITiledMapGroupLayer } from './ITiledMapGroupLayer';
+export { ITiledMapGroupLayer } from './ITiledMapGroupLayer';
 export * from './ITiledMap';
 export { upgradeMapToNewest } from './utility';

--- a/test/unit/index.spec.ts
+++ b/test/unit/index.spec.ts
@@ -1,12 +1,12 @@
-import { isTiledMapProperty, ITiledMapProperty, upgradeMapToNewest } from '../../src/index';
-import { isTiledMapChunk, ITiledMapChunk } from '../../src/index';
-import { isTiledMapTileLayer, ITiledMapTileLayer } from '../../src/index';
-import { isTiledMapLayer } from '../../src/index';
-import { isTiledMapObjectLayer, ITiledMapObjectLayer } from '../../src/index';
-import { isTiledMapImageLayer } from '../../src/index';
-import { isTiledMap, ITiledMap } from '../../src/index';
-import { isTiledMapTileset, ITiledMapTileset } from '../../src/index';
-import { isTiledMapGroupLayer, ITiledMapGroupLayer } from '../../src/index';
+import { ITiledMapProperty, upgradeMapToNewest } from '../../src/index';
+import { ITiledMapChunk } from '../../src/index';
+import { ITiledMapTileLayer } from '../../src/index';
+import { ITiledMapLayer } from '../../src/index';
+import { ITiledMapObjectLayer } from '../../src/index';
+import { ITiledMapImageLayer } from '../../src/index';
+import { ITiledMap } from '../../src/index';
+import { ITiledMapTileset } from '../../src/index';
+import { ITiledMapGroupLayer } from '../../src/index';
 
 const map = {
   compressionlevel: -1,
@@ -369,7 +369,7 @@ describe('Test ITiledMapProperty type guard', () => {
       type: 'string',
       value: 'hello',
     };
-    expect(isTiledMapProperty.parse(property)).toStrictEqual(property);
+    expect(ITiledMapProperty.parse(property)).toStrictEqual(property);
   });
 });
 
@@ -382,7 +382,7 @@ describe('Test ITiledMapChunk type guard', () => {
       x: 0,
       y: 0,
     };
-    expect(isTiledMapChunk.parse(property)).toStrictEqual(property);
+    expect(ITiledMapChunk.parse(property)).toStrictEqual(property);
   });
 
   it('should accept more data', () => {
@@ -394,7 +394,7 @@ describe('Test ITiledMapChunk type guard', () => {
       y: 0,
       foo: 'bar',
     } as ITiledMapChunk;
-    expect(isTiledMapChunk.passthrough().parse(property)).toStrictEqual(property);
+    expect(ITiledMapChunk.passthrough().parse(property)).toStrictEqual(property);
   });
 });
 
@@ -417,9 +417,9 @@ describe('Test ITiledMapLayer type guard', () => {
       x: 0,
       y: 0,
     };
-    expect(isTiledMapLayer.parse(property)).toStrictEqual(property);
-    expect(isTiledMapTileLayer.parse(property)).toStrictEqual(property);
-    expect(isTiledMapObjectLayer.safeParse(property).success).toBe(false);
+    expect(ITiledMapLayer.parse(property)).toStrictEqual(property);
+    expect(ITiledMapTileLayer.parse(property)).toStrictEqual(property);
+    expect(ITiledMapObjectLayer.safeParse(property).success).toBe(false);
   });
 });
 describe('Test ITiledMapTileset type guard', () => {
@@ -589,7 +589,7 @@ describe('Test ITiledMapTileset type guard', () => {
       ],
       tilewidth: 32,
     };
-    expect(isTiledMapTileset.parse(property)).toStrictEqual(property);
+    expect(ITiledMapTileset.parse(property)).toStrictEqual(property);
   });
 });
 
@@ -624,7 +624,7 @@ describe('Test ITiledMapObjectLayer type guard', () => {
       x: 0,
       y: 0,
     };
-    expect(isTiledMapObjectLayer.parse(property)).toStrictEqual(property);
+    expect(ITiledMapObjectLayer.parse(property)).toStrictEqual(property);
   });
 });
 
@@ -682,7 +682,7 @@ describe('Test ITiledMapTileset animated type guard', () => {
       ],
       tilewidth: 32,
     };
-    expect(isTiledMapTileset.parse(property)).toStrictEqual(property);
+    expect(ITiledMapTileset.parse(property)).toStrictEqual(property);
   });
 });
 
@@ -710,9 +710,9 @@ describe('Test ITiledMapObjectLayer type guard', () => {
       visible: true,
       type: 'objectgroup',
     } as ITiledMapObjectLayer;
-    expect(isTiledMapLayer.parse(property)).toStrictEqual(property);
-    expect(isTiledMapObjectLayer.parse(property)).toStrictEqual(property);
-    expect(isTiledMapImageLayer.safeParse(property).success).toBe(false);
+    expect(ITiledMapLayer.parse(property)).toStrictEqual(property);
+    expect(ITiledMapObjectLayer.parse(property)).toStrictEqual(property);
+    expect(ITiledMapImageLayer.safeParse(property).success).toBe(false);
   });
 });
 
@@ -736,7 +736,7 @@ describe('Test ITiledMapGroupLayer type guard', () => {
       y: 0,
     };
 
-    expect(isTiledMapLayer.parse(tileLayer)).toStrictEqual(tileLayer);
+    expect(ITiledMapLayer.parse(tileLayer)).toStrictEqual(tileLayer);
 
     const property = {
       id: 7,
@@ -749,30 +749,30 @@ describe('Test ITiledMapGroupLayer type guard', () => {
       y: 0,
     } as ITiledMapGroupLayer;
 
-    expect(isTiledMapGroupLayer.parse(property)).toStrictEqual(property);
-    expect(isTiledMapLayer.parse(property)).toStrictEqual(property);
-    expect(isTiledMapImageLayer.safeParse(property).success).toBe(false);
+    expect(ITiledMapGroupLayer.parse(property)).toStrictEqual(property);
+    expect(ITiledMapLayer.parse(property)).toStrictEqual(property);
+    expect(ITiledMapImageLayer.safeParse(property).success).toBe(false);
   });
 });
 
 describe('Test ITiledMap type guard', () => {
   it('should pass', () => {
-    expect(isTiledMap.parse(map)).toStrictEqual(map);
+    expect(ITiledMap.parse(map)).toStrictEqual(map);
   });
 });
 
 describe('Test ITiledMapGroupLayer type guard', () => {
   it('should pass', () => {
     const group = map.layers.find((layer) => layer.type === 'group');
-    expect(isTiledMapGroupLayer.parse(group)).toStrictEqual(group);
+    expect(ITiledMapGroupLayer.parse(group)).toStrictEqual(group);
   });
 });
 
 describe('Test ITiledMapObjectLayer type guard', () => {
   it('should pass', () => {
-    const group = isTiledMapGroupLayer.parse(map.layers.find((layer) => layer.type === 'group'));
+    const group = ITiledMapGroupLayer.parse(map.layers.find((layer) => layer.type === 'group'));
     const layer = group.layers[0];
 
-    expect(isTiledMapObjectLayer.parse(layer)).toStrictEqual(layer);
+    expect(ITiledMapObjectLayer.parse(layer)).toStrictEqual(layer);
   });
 });


### PR DESCRIPTION
Renaming all Zod type checkers from isTiledMapXXX to ITiledMapXXX.
This matches the naming convention of Zod.