### PR TITLE
Fix: objectgroup tiles are not arrays of layers, they are layers

### DIFF
--- a/src/ITiledMapTile.ts
+++ b/src/ITiledMapTile.ts
@@ -15,7 +15,7 @@ export const ITiledMapTile = z.object({
   y: z.number().optional(),
   width: z.number().optional(),
   height: z.number().optional(),
-  objectgroup: ITiledMapObjectLayer.array().optional(),
+  objectgroup: ITiledMapObjectLayer.optional(),
   probability: z.number().optional(),
   properties: ITiledMapProperty.array().optional(),
   class: z.string().optional(),

--- a/test/unit/index.spec.ts
+++ b/test/unit/index.spec.ts
@@ -1,4 +1,4 @@
-import { ITiledMapProperty, upgradeMapToNewest } from '../../src/index';
+import { ITiledMapProperty, ITiledMapTile, upgradeMapToNewest } from '../../src/index';
 import { ITiledMapChunk } from '../../src/index';
 import { ITiledMapTileLayer } from '../../src/index';
 import { ITiledMapLayer } from '../../src/index';
@@ -776,3 +776,40 @@ describe('Test ITiledMapObjectLayer type guard', () => {
     expect(ITiledMapObjectLayer.parse(layer)).toStrictEqual(layer);
   });
 });
+
+describe('Test ITileMapTile objectgroup type guard', () =>{
+  it('should pass', () =>{
+    const tile = {
+      "id":90,
+      "objectgroup":
+         {
+          "draworder":"index",
+          "name":"",
+          "objects":[
+                 {
+                  "type":"",
+                  "height":28,
+                  "id":6,
+                  "name":"",
+                  "rotation":0,
+                  "visible":true,
+                  "width":20,
+                  "x":0,
+                  "y":0
+                 }],
+          "opacity":1,
+          "type":"objectgroup",
+          "visible":true,
+          "x":0,
+          "y":0
+         },
+      "properties":[
+             {
+              "name":"collides",
+              "type":"bool",
+              "value":true
+             }]
+     };
+     ITiledMapTile.parse(tile);
+  })
+})


### PR DESCRIPTION
Thank you very much for sharing these useful type definitions!

While parsing my map, I noticed that there was a bug in the type definition for object groups: according to the [MapEditor JSON spec](https://doc.mapeditor.org/en/stable/reference/json-map-format/#tile-definition), an object group should be an object layer, not an array of object layers. This PR makes that change and adds a test using a format similar to the existing tests.