### PR TITLE
feat: Adding support for Tilesets referencing files

### DIFF
--- a/src/ITiledMapEmbeddedTileset.ts
+++ b/src/ITiledMapEmbeddedTileset.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+import { ITiledMapProperty } from './ITiledMapProperty';
+import { ITiledMapTerrain } from './ITiledMapTerrain';
+import { ITiledMapGrid } from './ITiledMapGrid';
+import { ITiledMapOffset } from './ITiledMapOffset';
+import { ITiledMapTile } from './ITiledMapTile';
+import { ITiledMapTransformations } from './ITiledMapTransformations';
+import { ITiledMapWangSet } from './ITiledMapWangSet';
+
+export const ITiledMapEmbeddedTileset = z.object({
+  name: z.string(),
+  image: z.string(),
+
+  backgroundcolor: z.string().optional(),
+  columns: z.number().optional(),
+  fillmode: z.enum(['stretch', 'preserve-aspect-fit']).optional(),
+  firstgid: z.number().optional(),
+  grid: ITiledMapGrid.optional(),
+  id: z.number().optional(),
+  imageheight: z.number().optional(),
+  imagewidth: z.number().optional(),
+  margin: z.number().optional(),
+  objectalignment: z.string().optional(),
+  properties: ITiledMapProperty.array().optional(),
+  //source: z.undefined(),
+  spacing: z.number().optional(),
+  terrains: ITiledMapTerrain.array().optional(),
+  tilecount: z.number().optional(),
+  tiledversion: z.string().optional(),
+  tileheight: z.number().optional(),
+  tileoffset: ITiledMapOffset.optional(),
+  tilerendersize: z.enum(['tile', 'grid']).optional(),
+  tiles: ITiledMapTile.array().optional(),
+  tilewidth: z.number().optional(),
+  transformations: ITiledMapTransformations.optional(),
+  transparentcolor: z.string().optional(),
+  type: z.literal('tileset').optional(),
+  class: z.string().optional(),
+  version: z.union([z.string(), z.number()]).optional(),
+  wangsets: ITiledMapWangSet.array().optional(),
+});
+
+export type ITiledMapEmbeddedTileset = z.infer<typeof ITiledMapEmbeddedTileset>;

--- a/src/ITiledMapTileset.ts
+++ b/src/ITiledMapTileset.ts
@@ -1,43 +1,7 @@
 import { z } from 'zod';
-import { ITiledMapProperty } from './ITiledMapProperty';
-import { ITiledMapTerrain } from './ITiledMapTerrain';
-import { ITiledMapGrid } from './ITiledMapGrid';
-import { ITiledMapOffset } from './ITiledMapOffset';
-import { ITiledMapTile } from './ITiledMapTile';
-import { ITiledMapTransformations } from './ITiledMapTransformations';
-import { ITiledMapWangSet } from './ITiledMapWangSet';
+import { ITiledMapEmbeddedTileset } from './ITiledMapEmbeddedTileset';
+import { ITiledMapTilesetReference } from './ITiledMapTilesetReference';
 
-export const ITiledMapTileset = z.object({
-  name: z.string(),
-  image: z.string(),
-
-  backgroundcolor: z.string().optional(),
-  columns: z.number().optional(),
-  fillmode: z.enum(['stretch', 'preserve-aspect-fit']).optional(),
-  firstgid: z.number().optional(),
-  grid: ITiledMapGrid.optional(),
-  id: z.number().optional(),
-  imageheight: z.number().optional(),
-  imagewidth: z.number().optional(),
-  margin: z.number().optional(),
-  objectalignment: z.string().optional(),
-  properties: ITiledMapProperty.array().optional(),
-  source: z.string().optional(),
-  spacing: z.number().optional(),
-  terrains: ITiledMapTerrain.array().optional(),
-  tilecount: z.number().optional(),
-  tiledversion: z.string().optional(),
-  tileheight: z.number().optional(),
-  tileoffset: ITiledMapOffset.optional(),
-  tilerendersize: z.enum(['tile', 'grid']).optional(),
-  tiles: ITiledMapTile.array().optional(),
-  tilewidth: z.number().optional(),
-  transformations: ITiledMapTransformations.optional(),
-  transparentcolor: z.string().optional(),
-  type: z.literal('tileset').optional(),
-  class: z.string().optional(),
-  version: z.union([z.string(), z.number()]).optional(),
-  wangsets: ITiledMapWangSet.array().optional(),
-});
+export const ITiledMapTileset = z.union([ITiledMapEmbeddedTileset, ITiledMapTilesetReference]);
 
 export type ITiledMapTileset = z.infer<typeof ITiledMapTileset>;

--- a/src/ITiledMapTilesetReference.ts
+++ b/src/ITiledMapTilesetReference.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const ITiledMapTilesetReference = z
+  .object({
+    firstgid: z.number(),
+    source: z.string(),
+  })
+  .strict();
+
+export type ITiledMapTilesetReference = z.infer<typeof ITiledMapTilesetReference>;

--- a/test/unit/index.spec.ts
+++ b/test/unit/index.spec.ts
@@ -7,6 +7,8 @@ import { ITiledMapImageLayer } from '../../src/index';
 import { ITiledMap } from '../../src/index';
 import { ITiledMapTileset } from '../../src/index';
 import { ITiledMapGroupLayer } from '../../src/index';
+import { ITiledMapEmbeddedTileset } from '../../src/ITiledMapEmbeddedTileset';
+import { ITiledMapTilesetReference } from '../../src/ITiledMapTilesetReference';
 
 const map = {
   compressionlevel: -1,
@@ -590,6 +592,28 @@ describe('Test ITiledMapTileset type guard', () => {
       tilewidth: 32,
     };
     expect(ITiledMapTileset.parse(property)).toStrictEqual(property);
+    expect(ITiledMapEmbeddedTileset.parse(property)).toStrictEqual(property);
+
+    const parsedProperty = ITiledMapTileset.parse(property);
+    if ('name' in parsedProperty) {
+      expect(parsedProperty.name).toStrictEqual('TDungeon');
+    }
+  });
+});
+
+describe('Test ITiledMapTilesetReference type guard', () => {
+  it('should pass', () => {
+    const property: ITiledMapTileset = {
+      firstgid: 1,
+      source: 'tileset_dungeon.tmx',
+    };
+    expect(ITiledMapTileset.parse(property)).toStrictEqual(property);
+    expect(ITiledMapTilesetReference.parse(property)).toStrictEqual(property);
+
+    const parsedProperty = ITiledMapTileset.parse(property);
+    if ('source' in parsedProperty) {
+      expect(parsedProperty.source).toStrictEqual('tileset_dungeon.tmx');
+    }
   });
 });
 
@@ -846,6 +870,44 @@ describe('Test ITiledMapObjectLayer type guard', () => {
     const layer = group.layers[0];
 
     expect(ITiledMapObjectLayer.parse(layer)).toStrictEqual(layer);
+  });
+});
+
+describe('Test ITileMapTile objectgroup type guard', () => {
+  it('should pass', () => {
+    const tile = {
+      id: 90,
+      objectgroup: {
+        draworder: 'index',
+        name: '',
+        objects: [
+          {
+            type: '',
+            height: 28,
+            id: 6,
+            name: '',
+            rotation: 0,
+            visible: true,
+            width: 20,
+            x: 0,
+            y: 0,
+          },
+        ],
+        opacity: 1,
+        type: 'objectgroup',
+        visible: true,
+        x: 0,
+        y: 0,
+      },
+      properties: [
+        {
+          name: 'collides',
+          type: 'bool',
+          value: true,
+        },
+      ],
+    };
+    ITiledMapTile.parse(tile);
   });
 });
 


### PR DESCRIPTION
In Tiled, a tileset can reference a .tsx or .tsj file. Previously, those "non embedded" tilesets where not properly parsed, though valid.

This new version validates those tilesets.

In order to discriminate between the 2 typeset types, you will now have to check if the "source" or "name" field is set.

```
if ("name" in tileset) {
    // tileset is an embedded tileset
}

if ("source" in tileset) {
    // tileset is an reference to an external tileset
}
```