### PR TITLE
Export tilesets types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,8 @@ export * from './ITiledMapTerrain';
 export * from './ITiledMapText';
 export * from './ITiledMapTile';
 export * from './ITiledMapTileset';
+export * from './ITiledMapEmbeddedTileset';
+export * from './ITiledMapTilesetReference';
 export * from './ITiledMapTransformations';
 export * from './ITiledMapWangColor';
 export * from './ITiledMapWangSet';


### PR DESCRIPTION
Export the subtypes of the ITiledMapTileset union type.