### PR TITLE
fix: Adding support for tilesets that are collections of images

### DIFF
--- a/src/ITiledMapEmbeddedCollectionOfImagesTileset.ts
+++ b/src/ITiledMapEmbeddedCollectionOfImagesTileset.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+import { ITiledMapEmbeddedTileset } from './ITiledMapEmbeddedTileset';
+import { ITiledMapTileWithImage } from './ITiledMapTileWithImage';
+
+export const ITiledEmbeddedCollectionOfImagesTileset = ITiledMapEmbeddedTileset.omit({
+  image: true,
+  tiles: true,
+}).and(
+  z.object({
+    tiles: z.array(ITiledMapTileWithImage).optional(),
+  }),
+);
+
+export type ITiledEmbeddedCollectionOfImagesTileset = z.infer<
+  typeof ITiledEmbeddedCollectionOfImagesTileset
+>;

--- a/src/ITiledMapTile.ts
+++ b/src/ITiledMapTile.ts
@@ -8,9 +8,6 @@ export const ITiledMapTile = z.object({
   id: z.number(),
 
   animation: ITiledMapFrame.array().optional(),
-  image: z.string().optional(),
-  imageheight: z.number().optional(),
-  imagewidth: z.number().optional(),
   x: z.number().optional(),
   y: z.number().optional(),
   width: z.number().optional(),

--- a/src/ITiledMapTileWithImage.ts
+++ b/src/ITiledMapTileWithImage.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+import { ITiledMapTile } from './ITiledMapTile';
+
+export const ITiledMapTileWithImage = ITiledMapTile.and(
+  z.object({
+    image: z.string(),
+    imageheight: z.number().optional(),
+    imagewidth: z.number().optional(),
+  }),
+);
+
+export type ITiledMapTileWithImage = z.infer<typeof ITiledMapTileWithImage>;

--- a/src/ITiledMapTileset.ts
+++ b/src/ITiledMapTileset.ts
@@ -1,7 +1,12 @@
 import { z } from 'zod';
 import { ITiledMapEmbeddedTileset } from './ITiledMapEmbeddedTileset';
 import { ITiledMapTilesetReference } from './ITiledMapTilesetReference';
+import { ITiledEmbeddedCollectionOfImagesTileset } from './ITiledMapEmbeddedCollectionOfImagesTileset';
 
-export const ITiledMapTileset = z.union([ITiledMapEmbeddedTileset, ITiledMapTilesetReference]);
+export const ITiledMapTileset = z.union([
+  ITiledMapEmbeddedTileset,
+  ITiledMapTilesetReference,
+  ITiledEmbeddedCollectionOfImagesTileset,
+]);
 
 export type ITiledMapTileset = z.infer<typeof ITiledMapTileset>;

--- a/test/unit/index.spec.ts
+++ b/test/unit/index.spec.ts
@@ -781,6 +781,34 @@ describe('Test ITiledMapTileset wangsets', () => {
     expect(ITiledMapTileset.parse(property)).toStrictEqual(property);
   });
 });
+describe('Test ITiledMapTileset collection of images', () => {
+  it('should pass', () => {
+    const property: ITiledMapTileset = {
+      columns: 0,
+      firstgid: 3020,
+      grid: {
+        height: 1,
+        orientation: 'orthogonal',
+        width: 1,
+      },
+      margin: 0,
+      name: 'collection-of-images',
+      spacing: 0,
+      tilecount: 1,
+      tileheight: 672,
+      tiles: [
+        {
+          id: 0,
+          image: 'map.png',
+          imageheight: 672,
+          imagewidth: 992,
+        },
+      ],
+      tilewidth: 992,
+    };
+    expect(ITiledMapTileset.parse(property)).toStrictEqual(property);
+  });
+});
 
 describe('Test ITiledMapObjectLayer type guard', () => {
   it('should pass', () => {


### PR DESCRIPTION
Some Tilesets in Tiled can be collections of images.